### PR TITLE
added hyperedges and clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ where `{id}` is the identifier of the routing option and `{value}` is a Boolean 
 
 Their meaning is documented in the [libavoid documentation](https://www.adaptagrams.org/documentation/namespaceAvoid.html#abc707ccbd6a0a7c29c124162c864ca05).
 
+An additional option that is not part of libavoid:
+
+* `enableHyperedgesFromCommonSource`
+
+This option creates hyperedges for all edges that share a common source. This is a post-process step and therefore adds additional computation time to the original layout run.
+
 ### Routing Penalties
 
 A [routing penalty](https://www.adaptagrams.org/documentation/classAvoid_1_1Router.html#acbda0590ff3234faad409e2f39e1c9ec) is applied using a line with the format
@@ -114,6 +120,22 @@ with the following placeholders:
  * `{target node id}` &ndash; identifier of the target node (or the node containing the target port)
  * `{source port id}` &ndash; identifier of the source port (ignored if there is none)
  * `{target port id}` &ndash; identifier of the target port (ignored if there is none)
+
+### Clusters
+
+Between the two lines delimiting the graph, a cluster is added using a line with the format
+```
+CLUSTER {id} {x1} {y1} {x2} {y2}
+```
+with the following placeholders:
+
+ * `{id}` &ndash; numeric (integer) identifier of the cluster
+ * `{x1}` &ndash; horizontal position of the top left corner
+ * `{y1}` &ndash; vertical position of the top left corner
+ * `{x2}` &ndash; horizontal position of the bottom right corner
+ * `{y2}` &ndash; vertical position of the bottom right corner
+
+A cluster only allows edges to cross its borders if they have a source- or endpoint inside the cluster.
 
 ## Output Format
 

--- a/include/LibavoidRouting.h
+++ b/include/LibavoidRouting.h
@@ -62,13 +62,14 @@
 /*
  * Routing Options
  */
-#define NUDGE_ORTHOGONAL_SEGMENTS			"nudgeOrthogonalSegmentsConnectedToShapes"
-#define IMPROVE_HYPEREDGES					"improveHyperedgeRoutesMovingJunctions"
-#define PENALISE_ORTH_SHATE_PATHS			"penaliseOrthogonalSharedPathsAtConnEnds"
-#define NUDGE_ORTHOGONAL_COLINEAR_SEGMENTS	"nudgeOrthogonalTouchingColinearSegments"
-#define NUDGE_PREPROCESSING					"performUnifyingNudgingPreprocessingStep"
-#define IMPROVE_HYPEREDGES_ADD_DELETE       "improveHyperedgeRoutesMovingAddingAndDeletingJunctions"
-#define NUDGE_SHARED_PATHS_COMMON_ENDPOINT  "nudgeSharedPathsWithCommonEndPoint"
+#define NUDGE_ORTHOGONAL_SEGMENTS			    "nudgeOrthogonalSegmentsConnectedToShapes"
+#define IMPROVE_HYPEREDGES					    "improveHyperedgeRoutesMovingJunctions"
+#define PENALISE_ORTH_SHATE_PATHS			    "penaliseOrthogonalSharedPathsAtConnEnds"
+#define NUDGE_ORTHOGONAL_COLINEAR_SEGMENTS	    "nudgeOrthogonalTouchingColinearSegments"
+#define NUDGE_PREPROCESSING					    "performUnifyingNudgingPreprocessingStep"
+#define IMPROVE_HYPEREDGES_ADD_DELETE           "improveHyperedgeRoutesMovingAddingAndDeletingJunctions"
+#define NUDGE_SHARED_PATHS_COMMON_ENDPOINT      "nudgeSharedPathsWithCommonEndPoint"
+#define ENABLE_HYPEREDGE_FROM_COMMON_SOURCE     "enableHyperedgeFromCommonSource"
 
 /*
  * Port Sides 
@@ -101,12 +102,16 @@ void setOption(std::string optionId, std::string token, Avoid::Router* router);
 void addNode(std::vector<std::string> &tokens, std::vector<Avoid::ShapeRef*> &shapes,
         Avoid::Router* router, std::string direction);
 
+void addCluster(std::vector<std::string> &tokens, Avoid::Router* router);
+
 void addPort(std::vector<std::string> &tokens, std::vector<Avoid::ShapeConnectionPin*> &pins,
         std::vector<Avoid::ShapeRef*> &shapes, Avoid::Router* router);
 
 void addEdge(std::vector<std::string> &tokens, Avoid::ConnType connectorType,
         std::vector<Avoid::ShapeRef*> &shapes, std::vector<Avoid::ConnRef*> &cons,
         Avoid::Router* router, std::string direction);
+
+void createHyperedges(std::vector<Avoid::ConnRef*> &cons, Avoid::Router* router);
 
 /**
  * Writing the graph to the output stream

--- a/include/LibavoidRouting.h
+++ b/include/LibavoidRouting.h
@@ -69,7 +69,7 @@
 #define NUDGE_PREPROCESSING					    "performUnifyingNudgingPreprocessingStep"
 #define IMPROVE_HYPEREDGES_ADD_DELETE           "improveHyperedgeRoutesMovingAddingAndDeletingJunctions"
 #define NUDGE_SHARED_PATHS_COMMON_ENDPOINT      "nudgeSharedPathsWithCommonEndPoint"
-#define ENABLE_HYPEREDGE_FROM_COMMON_SOURCE     "enableHyperedgeFromCommonSource"
+#define ENABLE_HYPEREDGES_FROM_COMMON_SOURCE     "enableHyperedgesFromCommonSource"
 
 /*
  * Port Sides 

--- a/src/LibavoidRouting.cpp
+++ b/src/LibavoidRouting.cpp
@@ -5,6 +5,7 @@
  * @section LICENSE
  *
  * Copyright (c) 2013, 2022 Kiel University and others.
+ *               2023 Primetals Technologies Austria GmbH
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,7 +138,7 @@ void HandleRequest(chunk_istream& stream, ostream& out) {
             } else if (optionId == DIRECTION) {
                 // layout direction
                 direction = tokens[2];
-            } else if (optionId == ENABLE_HYPEREDGE_FROM_COMMON_SOURCE) {
+            } else if (optionId == ENABLE_HYPEREDGES_FROM_COMMON_SOURCE) {
                 hyperedges = true;
             } else {
                 cerr << "ERROR: unknown option " << tokens[1] << "." << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,8 @@ void HandleRequest(chunk_istream& stream, ostream& out) {
 	bool debug = false;
     // has the graph declaration started?
     bool graphDecl = false;
+    // have hyperedges been enabled? will result in decreased performance
+    bool hyperedges = false;
 
     // read graph from stdin
     for (std::string line; std::getline(std::cin, line);) {
@@ -136,6 +138,8 @@ void HandleRequest(chunk_istream& stream, ostream& out) {
             } else if (optionId == DIRECTION) {
                 // layout direction
                 direction = tokens[2];
+            } else if (optionId == ENABLE_HYPEREDGE_FROM_COMMON_SOURCE) {
+                hyperedges = true;
             } else {
                 cerr << "ERROR: unknown option " << tokens[1] << "." << endl;
             }
@@ -155,6 +159,22 @@ void HandleRequest(chunk_istream& stream, ostream& out) {
             }
 
             addNode(tokens, shapes, router, direction);
+
+        } else if (tokens[0] == "CLUSTER") {
+            if (router == NULL) {
+                router = new Avoid::Router(Avoid::OrthogonalRouting);
+            }
+            if (!graphDecl) {
+                cerr << "ERROR: missing declaration of GRAPH" << endl;
+                graphDecl = true;
+            }
+            // format:
+            // id topleft bottomright
+            if (tokens.size() != 6) {
+                cerr << "ERROR: invalid cluster format" << endl;
+            }
+
+            addCluster(tokens, router);
 
         } else if (tokens[0] == "PORT") {
             if (router == NULL) {
@@ -220,6 +240,9 @@ void HandleRequest(chunk_istream& stream, ostream& out) {
 
     // perform edge routing
     router->processTransaction();
+    if (hyperedges) {
+        createHyperedges(cons, router);
+    }
 
 #ifdef DEBUG_EXEC_TIME
     QueryPerformanceCounter(&t2);


### PR DESCRIPTION
Clusters are added just like nodes so no groundbreaking changes there. They only need to be added into the graph and should overlap with their "children".

I put the hyperedge code after the "main" layout code as to not slow down a normal layout run. Hyperedges are quite slow and should therefore only be explicitly set if they are really wanted.

Whats still missing is their counterpart in ELK itself and I hope to do that in the near future. The option for hyperedges is relatively straight forward. The problem i see is how to model clusters since elk nodes are hierarchical. I would really welcome some thoughts on that matter. :smile: 